### PR TITLE
Fix for class-api fatal error fix etc

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -449,7 +449,7 @@ class API {
 			return array( 'success' => true, 'data' => $response['body'] ) ;
 
 		} else {
-			return array( 'success' => false, 'msg' => $response->get_error_message() ) ;
+			return array( 'success' => false, 'msg' => $response['body'] ) ;
 		}
 	}
 


### PR DESCRIPTION
Response object is an array, doesn't have methods.  Have it use the body on the case when the oauth token expires.

@DMinton 
